### PR TITLE
Display temperature in Celsius

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # My Weather App
 
-This is a simple weather application built with Flask. It allows users to enter a city name and get the current weather information for that city.
+This is a simple weather application built with Flask. It allows users to enter a city name and get the current weather information for that city. Now, the application displays temperature in Celsius degrees.
 
 # Installation
 
@@ -46,7 +46,7 @@ MIT (https://choosealicense.com/licenses/mit/)
 
 ## Usage
 
-To use this application, first install the necessary dependencies by running `pip install -r requirements.txt` in your terminal. Once the installation is complete, you can start the application by running `python run.py`.
+To use this application, first install the necessary dependencies by running `pip install -r requirements.txt` in your terminal. Once the installation is complete, you can start the application by running `python run.py`. The application now displays temperature information in Celsius degrees.
 
 ## Files
 
@@ -58,8 +58,7 @@ To use this application, first install the necessary dependencies by running `pi
 
 ## Testing
 
-To run the tests for this application, use the command `python -m unittest discover tests` in your terminal. This will run the tests defined in the `tests/test_views.py` file.
-
+To run the tests for this application, use the command `python -m unittest discover tests` in your terminal. This will run the tests defined in the `tests/test_views.py` file, including tests to verify that temperature is displayed in Celsius degrees.
 
 ## Contributing
 

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -16,7 +16,7 @@
         <h2>Weather in {{ weather.city }}</h2>
         <img src="http://openweathermap.org/img/w/{{ weather.icon }}.png" alt="Weather icon">
         <p>{{ weather.description }}</p>
-        <p>Temperature: {{ weather.temperature }}</p>
+        <p>Temperature: {{ weather.temperature }} °C</p>
     </div>
     {% endif %}
     <script src="{{ url_for('static', filename='js/main.js') }}"></script>

--- a/app/views.py
+++ b/app/views.py
@@ -9,7 +9,8 @@ def index():
     if request.method == 'POST':
         city = request.form['city']
 
-        url = f'http://api.openweathermap.org/data/2.5/weather?q={city}&appid=b5268fcd2ca37ab2198170fac2825453'
+        # Added &units=metric to fetch temperature in Celsius
+        url = f'http://api.openweathermap.org/data/2.5/weather?q={city}&appid=b5268fcd2ca37ab2198170fac2825453&units=metric'
 
         response = requests.get(url).json()
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -17,3 +17,9 @@ class TestViews(unittest.TestCase):
             response = self.app.post('/', data={'city': city})
             self.assertEqual(response.status_code, 200)
             self.assertIn(bytes(city, 'utf-8'), response.data)
+
+    # Test to verify temperature is displayed in Celsius
+    def test_temperature_display_in_celsius(self):
+        response = self.app.get('/')
+        self.assertIn(b'Temperature: ', response.data)
+        self.assertIn(b'°C', response.data)


### PR DESCRIPTION
Related to #2

This pull request updates the weather application to display temperatures in Celsius degrees, aligning with user preferences for temperature units. 

- **API Call Modification**: Modifies the API URL in `app/views.py` to include `&units=metric`, ensuring temperatures are fetched in Celsius.
- **UI Update**: Adjusts the temperature display in `app/templates/index.html` to specify Celsius (°C) alongside the temperature value.
- **Testing**: Adds a new test in `tests/test_views.py` to verify that the temperature is correctly displayed in Celsius on the application's interface.
- **Documentation**: Updates `README.md` to note that the application now displays temperature in Celsius, providing clarity on the temperature unit used for new users.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/msanzdelrio-demo-resources/the-weather-app/issues/2?shareId=aa3947ac-b932-4140-803e-2a843ff69371).