### PR TITLE
Convert temperature display to Celsius

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # My Weather App
 
-This is a simple weather application built with Flask. It allows users to enter a city name and get the current weather information for that city.
+This is a simple weather application built with Flask. It allows users to enter a city name and get the current weather information for that city. Now, the application displays temperature in Celsius degrees.
 
 # Installation
 

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -16,7 +16,7 @@
         <h2>Weather in {{ weather.city }}</h2>
         <img src="http://openweathermap.org/img/w/{{ weather.icon }}.png" alt="Weather icon">
         <p>{{ weather.description }}</p>
-        <p>Temperature: {{ weather.temperature }}</p>
+        <p>Temperature: {{ weather.temperature }} °C</p>
     </div>
     {% endif %}
     <script src="{{ url_for('static', filename='js/main.js') }}"></script>

--- a/app/views.py
+++ b/app/views.py
@@ -9,7 +9,7 @@ def index():
     if request.method == 'POST':
         city = request.form['city']
 
-        url = f'http://api.openweathermap.org/data/2.5/weather?q={city}&appid=b5268fcd2ca37ab2198170fac2825453'
+        url = f'http://api.openweathermap.org/data/2.5/weather?q={city}&appid=b5268fcd2ca37ab2198170fac2825453&units=metric'
 
         response = requests.get(url).json()
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -17,3 +17,8 @@ class TestViews(unittest.TestCase):
             response = self.app.post('/', data={'city': city})
             self.assertEqual(response.status_code, 200)
             self.assertIn(bytes(city, 'utf-8'), response.data)
+
+    def test_temperature_display_in_celsius(self):
+        response = self.app.get('/')
+        self.assertIn(b'Temperature: ', response.data)
+        self.assertIn(b'°C', response.data)


### PR DESCRIPTION
Related to #2

Updates the weather application to display temperatures in Celsius degrees.

- **API Call Modification**: Modifies the API call in `app/views.py` to include `&units=metric`, ensuring temperatures are fetched in Celsius.
- **UI Update**: Adjusts the temperature display in `app/templates/index.html` to specify that the temperature is in Celsius by adding "°C" to the temperature value.
- **Documentation Enhancement**: Updates `README.md` to note that the application now displays temperature in Celsius, informing users of this new feature.
- **Testing**: Adds a new test in `tests/test_views.py` to verify that temperatures are displayed in Celsius, ensuring the application's functionality aligns with the user's expectations.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/msanzdelrio-demo-resources/the-weather-app/issues/2?shareId=36163237-aa53-40bb-bfe1-c2e3b2c66926).