### PR TITLE
Display temperature in Celsius degrees

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # My Weather App
 
-This is a simple weather application built with Flask. It allows users to enter a city name and get the current weather information for that city.
+This is a simple weather application built with Flask. It allows users to enter a city name and get the current weather information for that city. Now, the application displays temperature in Celsius degrees.
 
 # Installation
 

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -16,7 +16,7 @@
         <h2>Weather in {{ weather.city }}</h2>
         <img src="http://openweathermap.org/img/w/{{ weather.icon }}.png" alt="Weather icon">
         <p>{{ weather.description }}</p>
-        <p>Temperature: {{ weather.temperature }}</p>
+        <p>Temperature: {{ weather.temperature }} °C</p>
     </div>
     {% endif %}
     <script src="{{ url_for('static', filename='js/main.js') }}"></script>

--- a/app/views.py
+++ b/app/views.py
@@ -9,7 +9,8 @@ def index():
     if request.method == 'POST':
         city = request.form['city']
 
-        url = f'http://api.openweathermap.org/data/2.5/weather?q={city}&appid=b5268fcd2ca37ab2198170fac2825453'
+        # Added &units=metric to fetch temperature in Celsius
+        url = f'http://api.openweathermap.org/data/2.5/weather?q={city}&appid=b5268fcd2ca37ab2198170fac2825453&units=metric'
 
         response = requests.get(url).json()
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -17,3 +17,8 @@ class TestViews(unittest.TestCase):
             response = self.app.post('/', data={'city': city})
             self.assertEqual(response.status_code, 200)
             self.assertIn(bytes(city, 'utf-8'), response.data)
+
+    def test_temperature_display_in_celsius(self):
+        response = self.app.get('/')
+        self.assertIn(b'Temperature: ', response.data)
+        self.assertIn(b'°C', response.data)


### PR DESCRIPTION
Related to #2

This pull request updates the weather application to display temperatures in Celsius degrees, aligning with user preferences for temperature units. 

- **API Call Modification**: Modifies the API call in `app/views.py` to include `&units=metric`, ensuring temperatures are fetched in Celsius.
- **UI Update**: Updates `app/templates/index.html` to display temperatures with a Celsius indicator (°C), providing clear information to users.
- **Testing**: Adds a new test in `tests/test_views.py` to verify that temperatures are correctly displayed in Celsius, enhancing test coverage.
- **Documentation**: Updates `README.md` to note that the application now displays temperatures in Celsius, informing current and potential users of this feature.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/msanzdelrio-demo-resources/the-weather-app/issues/2?shareId=1d1955f6-603d-4d7a-9469-78d5edd8590d).