### PR TITLE
Update temperature to show in Celsius and include visibility and snow fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ python run.py
 ```
 5. Open your web browser and navigate to http://localhost:5000.
 6. Enter a city name in the input field and click "Get Weather".
-7. Verify that the weather information, including wind speed, rain %, and pressure, is displayed correctly.
+7. Verify that the weather information, including wind speed, rain %, pressure, visibility, and snow %, is displayed correctly.
 
 ## Contributing
 

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -10,6 +10,8 @@ document.getElementById('weatherForm').addEventListener('submit', function(event
             document.getElementById('windSpeed').textContent = 'Wind Speed: ' + data.wind_speed + ' m/s';
             document.getElementById('rain').textContent = 'Rain: ' + data.rain + ' %';
             document.getElementById('pressure').textContent = 'Pressure: ' + data.pressure + ' hPa';
+            document.getElementById('visibility').textContent = 'Visibility: ' + data.visibility + ' m';
+            document.getElementById('snow').textContent = 'Snow: ' + data.snow + ' %';
         })
         .catch(function(error) {
             console.error('Error:', error);

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -20,7 +20,7 @@
             <h2>{{ weather.city }}</h2>
             <img src="http://openweathermap.org/img/w/{{ weather.icon }}.png" alt="Weather icon">
             <div>
-                <span>{{ weather.temperature }}</span>
+                <span>{{ weather.temperature }} °C</span>
                 <p>{{ weather.description }}</p>
             </div>
         </div>
@@ -28,6 +28,8 @@
             <p>Wind Speed: {{ weather.wind_speed }} m/s</p>
             <p>Rain: {{ weather.rain }} %</p>
             <p>Pressure: {{ weather.pressure }} hPa</p>
+            <p>Visibility: {{ weather.visibility }} m</p>
+            <p>Snow: {{ weather.snow }} %</p>
         </div>
     </div>
     {% endif %}

--- a/app/views.py
+++ b/app/views.py
@@ -16,15 +16,21 @@ def index():
 
         response = requests.get(url).json()
 
+        temperature_celsius = round(response['main']['temp'] - 273.15, 1)
+        visibility = response.get('visibility', 'N/A')
+        snow = response.get('snow', {}).get('1h', 0)
+
         weather = {
             'country': response['sys']['country'],
             'city': response['name'],
-            'temperature': response['main']['temp'],
+            'temperature': temperature_celsius,
             'description': response['weather'][0]['description'],
             'icon': response['weather'][0]['icon'],
             'wind_speed': response['wind']['speed'],
             'rain': response.get('rain', {}).get('1h', 0),
-            'pressure': response['main']['pressure']
+            'pressure': response['main']['pressure'],
+            'visibility': visibility,
+            'snow': snow
         }
 
     return render_template('index.html', weather=weather)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -20,6 +20,8 @@ class TestViews(unittest.TestCase):
             self.assertIn(b'Wind Speed:', response.data)
             self.assertIn(b'Rain:', response.data)
             self.assertIn(b'Pressure:', response.data)
+            self.assertIn(b'Visibility:', response.data)
+            self.assertIn(b'Snow:', response.data)
 
     def test_weather_info(self):
         response = self.app.post('/', data={'city': 'London'})
@@ -29,3 +31,21 @@ class TestViews(unittest.TestCase):
         self.assertIn(b'Wind Speed:', response.data)
         self.assertIn(b'Rain:', response.data)
         self.assertIn(b'Pressure:', response.data)
+        self.assertIn(b'Visibility:', response.data)
+        self.assertIn(b'Snow:', response.data)
+
+    def test_temperature_in_celsius(self):
+        response = self.app.post('/', data={'city': 'London'})
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b'Temperature:', response.data)
+        self.assertIn(b' \xc2\xb0C', response.data)  # Check for Celsius symbol
+
+    def test_visibility_field(self):
+        response = self.app.post('/', data={'city': 'London'})
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b'Visibility:', response.data)
+
+    def test_snow_field(self):
+        response = self.app.post('/', data={'city': 'London'})
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b'Snow:', response.data)


### PR DESCRIPTION
Related to #23

Update temperature to show in Celsius and include `visibility` and `snow %` fields.

* Convert temperature to Celsius and round to 1 decimal in `app/views.py`.
* Add `visibility` and `snow` fields to the response in `app/views.py`.
* Display temperature in Celsius, visibility, and snow fields in the UI in `app/templates/index.html`.
* Handle `visibility` and `snow` fields in the JavaScript in `app/static/js/main.js`.
* Add tests for temperature in Celsius, visibility, and snow fields in `tests/test_views.py`.
* Update documentation to reflect changes in temperature, visibility, and snow fields in `README.md`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/msanzdelrio-demo-resources/SkyScope/pull/46?shareId=a81905bd-f356-450f-ac49-0a5989222a92).